### PR TITLE
fix: Windows install script

### DIFF
--- a/scripts/install_pz.bat
+++ b/scripts/install_pz.bat
@@ -1,1 +1,1 @@
-steamcmd +force_install_dir %cd%/pzserver/ +login anonymous +app_update 380870 -beta stable validate +quit
+steamcmd +force_install_dir %~dp0/pzserver/ +login anonymous +app_update 380870 -beta stable validate +quit


### PR DESCRIPTION
#### Administrative rights elevation leads to wrong behavior
Using `%cd%` with bat file executed as admin, creates path to System32.
![image](https://user-images.githubusercontent.com/61511416/205417669-d1b47c66-7f6e-418c-a15d-c62a0e79f885.png)
